### PR TITLE
feat: show region-aware language names

### DIFF
--- a/core/main/src/main/java/com/rk/xededitor/ui/screens/settings/language/Language.kt
+++ b/core/main/src/main/java/com/rk/xededitor/ui/screens/settings/language/Language.kt
@@ -98,7 +98,7 @@ fun LanguageScreen(modifier: Modifier = Modifier) {
                 indianLangs.forEach { locale ->
                     SettingsToggle(
                         modifier = Modifier,
-                        label = locale.getDisplayLanguage(locale),
+                        label = locale.getDisplayName(locale),
                         default = false,
                         sideEffect = {
                             setAppLanguage(locale)
@@ -129,7 +129,7 @@ fun LanguageScreen(modifier: Modifier = Modifier) {
                 languages.forEach { locale ->
                     SettingsToggle(
                         modifier = Modifier,
-                        label = locale.getDisplayLanguage(locale),
+                        label = locale.getDisplayName(locale),
                         default = false,
                         sideEffect = {
                             setAppLanguage(locale)


### PR DESCRIPTION
## Summary
- show locale display names in language picker so region-specific languages display

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1159f7948323b8b07180cf436f73